### PR TITLE
Fixed usage of passed default value to all bands of writableraster

### DIFF
--- a/jgrassgears/src/main/java/org/jgrasstools/gears/utils/coverage/CoverageUtilities.java
+++ b/jgrassgears/src/main/java/org/jgrasstools/gears/utils/coverage/CoverageUtilities.java
@@ -206,9 +206,12 @@ public class CoverageUtilities {
                 // autobox only once
                 double v = value;
 
+                double[] dArray = new double[sampleModel.getNumBands()];
+                for(int i = 0; i<dArray.length; i++){dArray[i]=v;}
+                
                 for( int y = 0; y < height; y++ ) {
                     for( int x = 0; x < width; x++ ) {
-                        raster.setSample(x, y, 0, v);
+                        raster.setPixel(x, y, dArray);
                     }
                 }
             }


### PR DESCRIPTION
The proposed fix will use the user-provided default value to initialize all bands of a multi-banded writeable raster.
Previous code correctly initialised just first band while fell back on using 0.0 as the default for any other eventual band so delivering an inconsistently initialised multi-band raster.
