### PR TITLE
Fixed OmsFlowDirection.html - no outlet marked

### DIFF
--- a/hortonmachine/src/main/resources/org/jgrasstools/hortonmachine/modules/geomorphology/flow/OmsFlowDirections.html
+++ b/hortonmachine/src/main/resources/org/jgrasstools/hortonmachine/modules/geomorphology/flow/OmsFlowDirections.html
@@ -16,4 +16,4 @@ maximal steepest descent slope, choosing it among 8 possible directions around t
 <br>
 <h3>Notes</h3>
 The maximal slope direction is chosen among the 8 possible directions
-and codified with numbers ranging from 0 to 8. Such method derives from the one originarily used by D. Tarboton in his Phd thesis. However the outlets are marked with value 10 (beware: many other programs assume it).
+and codified with numbers ranging from 0 to 8. Such method derives from the one originarily used by D. Tarboton in his Phd thesis. Note that the outlets are NOT marked with value 10 (beware: many other programs assume it so consider running OmsMarkoutlets model on the flow map out of this tool).


### PR DESCRIPTION
Documentation of OmsFlowDirection is fixed: now it highlights the module is NOT marking outlets with value 10.
