### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -920,6 +920,7 @@
 					<encoding>UTF-8</encoding>
 				        <release>11</release>
 					<debug>true</debug>
+					<fork>true</fork>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -1110,6 +1111,7 @@
 							<source>1.8</source>
 							<target>1.8</target>
 							<encoding>UTF-8</encoding>
+					<fork>true</fork>
 						</configuration>
 					</plugin>
 				</plugins>


### PR DESCRIPTION

Maven allows you to run the compiler as a separate process by setting `<fork>true</fork>`. This feature can lead to much less garbage collection and make Maven build faster. This project has more than 1000 source files. We can consider enabling this feature.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
