### PR TITLE
Use stac asset id as the identifier

### DIFF
--- a/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacAsset.java
+++ b/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacAsset.java
@@ -27,6 +27,7 @@ import it.geosolutions.imageioimpl.plugins.cog.HttpRangeReader;
  */
 public class HMStacAsset {
 
+    private String id;
     private String title;
     private String type;
     private String nonValidReason;
@@ -35,7 +36,8 @@ public class HMStacAsset {
     private double noValue = HMConstants.doubleNovalue;
     private double resolution;
 
-    public HMStacAsset( JsonNode assetNode ) {
+    public HMStacAsset( String id, JsonNode assetNode ) {
+        this.id = id;
         JsonNode typeNode = assetNode.get("type");
         if (typeNode != null) {
             type = typeNode.textValue();
@@ -120,6 +122,10 @@ public class HMStacAsset {
 
     public GridCoverage2D readRaster( RegionMap region ) throws Exception {
         return readRaster(region, null, null);
+    }
+
+    public String getId() {
+        return id;
     }
 
     public String getTitle() {

--- a/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacCollection.java
+++ b/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacCollection.java
@@ -207,7 +207,7 @@ public class HMStacCollection {
             RegionMap readRegion = RegionMap.fromBoundsAndGrid(roiEnvCurrentItemCrs.getMinX(), roiEnvCurrentItemCrs.getMaxX(),
                     roiEnvCurrentItemCrs.getMinY(), roiEnvCurrentItemCrs.getMaxY(), cols, rows);
 
-            HMStacAsset asset = item.getAssets().stream().filter(as -> as.getTitle().equals(bandName)).findFirst().get();
+            HMStacAsset asset = item.getAssets().stream().filter(as -> as.getId().equals(bandName)).findFirst().get();
             int lastSlash = asset.getAssetUrl().lastIndexOf('/');
             fileName = asset.getAssetUrl().substring(lastSlash + 1);
             if (outRaster == null) {

--- a/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacItem.java
+++ b/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacItem.java
@@ -125,10 +125,11 @@ public class HMStacItem {
                 ObjectNode assets = (ObjectNode) top.get("assets");
 
                 if (assets != null) {
-                    Iterator<JsonNode> assetsIterator = assets.elements();
-                    while( assetsIterator.hasNext() ) {
-                        JsonNode assetNode = assetsIterator.next();
-                        HMStacAsset hmAsset = new HMStacAsset(assetNode);
+                    Iterator<String> assetIds= assets.fieldNames();
+                    while ( assetIds.hasNext() ) {
+                        String assetId = assetIds.next();
+                        JsonNode assetNode = assets.get(assetId);
+                        HMStacAsset hmAsset = new HMStacAsset(assetId, assetNode);
                         if (hmAsset.isValid()) {
                             assetsList.add(hmAsset);
                         }

--- a/gears/src/test/java/org/hortonmachine/gears/modules/TestStacAsset.java
+++ b/gears/src/test/java/org/hortonmachine/gears/modules/TestStacAsset.java
@@ -1,0 +1,66 @@
+package org.hortonmachine.gears.modules;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.hortonmachine.gears.io.stac.HMStacAsset;
+import org.hortonmachine.gears.utils.HMTestCase;
+
+public class TestStacAsset extends HMTestCase {
+
+    protected void setUp() throws Exception {
+
+    }
+
+    // Asset JSONs obtained from the documentation, reformatted and modified
+    // https://github.com/stac-extensions/raster/blob/main/examples/item-sentinel2.json#L177
+
+    public void testCreateValidStacAsset() throws JsonProcessingException {
+        String assetJSON = "{\"title\":\"Band 1 (coastal) BOA reflectance\",\"type\":\"image/tiff; application=geotiff; profile=cloud-optimized\",\"roles\":[\"data\"],\"gsd\":60,\"eo:bands\":[{\"name\":\"B01\",\"common_name\":\"coastal\",\"center_wavelength\":0.4439,\"full_width_half_max\":0.027}],\"href\":\"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B01.tif\",\"proj:shape\":[1830,1830],\"proj:transform\":[60,0,399960,0,-60,4200000,0,0,1],\"raster:bands\":[{\"data_type\":\"uint16\",\"spatial_resolution\":60,\"bits_per_sample\":15,\"nodata\":0,\"statistics\":{\"minimum\":1,\"maximum\":20567,\"mean\":2339.4759595597,\"stddev\":3026.6973619954,\"valid_percent\":99.83}}]}";
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode node = mapper.readTree(assetJSON);
+
+        HMStacAsset asset = new HMStacAsset("B01", node);
+
+        assertTrue(asset.isValid());
+        assertEquals("B01", asset.getId());
+        assertEquals("Band 1 (coastal) BOA reflectance", asset.getTitle());
+        assertEquals("image/tiff; application=geotiff; profile=cloud-optimized", asset.getType());
+        assertEquals("https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B01.tif", asset.getAssetUrl());
+        assertEquals(0.0, asset.getNoValue());
+    }
+
+    public void testCreateInvalidStacAssetTypeInformationNotAvailable() throws JsonProcessingException {
+        String assetJSON = "{\"title\":\"Band 1 (coastal) BOA reflectance\",\"roles\":[\"data\"],\"gsd\":60,\"eo:bands\":[{\"name\":\"B01\",\"common_name\":\"coastal\",\"center_wavelength\":0.4439,\"full_width_half_max\":0.027}],\"href\":\"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B01.tif\",\"proj:shape\":[1830,1830],\"proj:transform\":[60,0,399960,0,-60,4200000,0,0,1],\"raster:bands\":[{\"data_type\":\"uint16\",\"spatial_resolution\":60,\"bits_per_sample\":15,\"nodata\":0,\"statistics\":{\"minimum\":1,\"maximum\":20567,\"mean\":2339.4759595597,\"stddev\":3026.6973619954,\"valid_percent\":99.83}}]}";
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode node = mapper.readTree(assetJSON);
+
+        HMStacAsset asset = new HMStacAsset("B01", node);
+
+        assertFalse(asset.isValid());
+        assertEquals("type information not available", asset.getNonValidReason());
+    }
+
+    public void testCreateInvalidStacAssetNotACOG() throws JsonProcessingException {
+        String assetJSON = "{\"title\":\"Band 1 (coastal) BOA reflectance\",\"type\":\"image/tiff;\",\"roles\":[\"data\"],\"gsd\":60,\"eo:bands\":[{\"name\":\"B01\",\"common_name\":\"coastal\",\"center_wavelength\":0.4439,\"full_width_half_max\":0.027}],\"href\":\"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B01.tif\",\"proj:shape\":[1830,1830],\"proj:transform\":[60,0,399960,0,-60,4200000,0,0,1],\"raster:bands\":[{\"data_type\":\"uint16\",\"spatial_resolution\":60,\"bits_per_sample\":15,\"nodata\":0,\"statistics\":{\"minimum\":1,\"maximum\":20567,\"mean\":2339.4759595597,\"stddev\":3026.6973619954,\"valid_percent\":99.83}}]}";
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode node = mapper.readTree(assetJSON);
+
+        HMStacAsset asset = new HMStacAsset("B01", node);
+
+        assertFalse(asset.isValid());
+        assertEquals("not a COG", asset.getNonValidReason());
+    }
+
+    public void testCreateInvalidStacAssetRasterBandsMetadataMissing() throws JsonProcessingException {
+        String assetJSON = "{\"title\":\"Band 1 (coastal) BOA reflectance\",\"type\":\"image/tiff; application=geotiff; profile=cloud-optimized\",\"roles\":[\"data\"],\"gsd\":60,\"eo:bands\":[{\"name\":\"B01\",\"common_name\":\"coastal\",\"center_wavelength\":0.4439,\"full_width_half_max\":0.027}],\"href\":\"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B01.tif\",\"proj:shape\":[1830,1830],\"proj:transform\":[60,0,399960,0,-60,4200000,0,0,1],\"raster:bands\":[]}";
+        ObjectMapper mapper = new ObjectMapper();
+        JsonNode node = mapper.readTree(assetJSON);
+
+        HMStacAsset asset = new HMStacAsset("B01", node);
+
+        assertFalse(asset.isValid());
+        assertEquals("raster bands metadata missing", asset.getNonValidReason());
+    }
+
+}


### PR DESCRIPTION
Hi! This is my first Pull Request on this repository.

This small change I am proposing would make the id of the asset the primary identifier of a HMStacAsset. Currently, the "title" field is being used, but this could cause issues as that field might not exist or might not be unique ([link to the docs](https://github.com/radiantearth/stac-spec/blob/master/item-spec/item-spec.md#asset-object)).

I would like to know if there some standards I should follow before sending you a non-draft Pull Request. I was thinking on creating some tests to validate the changes. How should they be added?