### PR TITLE
Add new search options

### DIFF
--- a/gears/pom.xml
+++ b/gears/pom.xml
@@ -145,7 +145,11 @@
 			<groupId>it.geosolutions.imageio-ext</groupId>
 			<artifactId>imageio-ext-cog-rangereader-http</artifactId>
 		</dependency>
-		
+		<dependency>
+			<groupId>it.geosolutions.imageio-ext</groupId>
+			<artifactId>imageio-ext-cog-rangereader-s3</artifactId>
+		</dependency>
+
 		<dependency>
 			<groupId>org.geotools</groupId>
 			<artifactId>gt-imagemosaic</artifactId>

--- a/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacAsset.java
+++ b/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacAsset.java
@@ -1,8 +1,9 @@
 package org.hortonmachine.gears.io.stac;
 
-import java.net.URI;
-import java.util.Iterator;
-
+import com.fasterxml.jackson.databind.JsonNode;
+import it.geosolutions.imageio.core.BasicAuthURI;
+import it.geosolutions.imageio.plugins.cog.CogImageReadParam;
+import it.geosolutions.imageioimpl.plugins.cog.*;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.gce.geotiff.GeoTiffReader;
 import org.hortonmachine.gears.libs.modules.HMConstants;
@@ -11,20 +12,11 @@ import org.hortonmachine.gears.utils.coverage.CoverageUtilities;
 import org.opengis.parameter.GeneralParameterValue;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
-import it.geosolutions.imageio.core.BasicAuthURI;
-import it.geosolutions.imageio.plugins.cog.CogImageReadParam;
-import it.geosolutions.imageioimpl.plugins.cog.CogImageInputStreamSpi;
-import it.geosolutions.imageioimpl.plugins.cog.CogImageReaderSpi;
-import it.geosolutions.imageioimpl.plugins.cog.CogSourceSPIProvider;
-import it.geosolutions.imageioimpl.plugins.cog.HttpRangeReader;
-import it.geosolutions.imageioimpl.plugins.cog.S3RangeReader;
-import it.geosolutions.imageioimpl.plugins.cog.RangeReader;
+import java.util.Iterator;
 
 /**
  * An asset from a stac item.
- * 
+ *
  * @author Andrea Antonello (www.hydrologis.com)
  *
  */
@@ -99,24 +91,18 @@ public class HMStacAsset {
 
     /**
      * Read the asset's coverage into a local raster.
-     * 
+     *
      * @param region and optional region to read from.
      * @param user an optional user in case of authentication.
      * @param password an optional password in case of authentication.
-     * @param awsRegion an optional value for the AWS region in case of S3 authentication.
      * @return the read raster from the asset's url.
-     * @throws Exception 
+     * @throws Exception
      */
-    public GridCoverage2D readRaster( RegionMap region, String user, String password, String awsRegion ) throws Exception {
+    public GridCoverage2D readRaster( RegionMap region, String user, String password ) throws Exception {
         BasicAuthURI cogUri = new BasicAuthURI(assetUrl, false);
         if (user != null && password != null) {
             cogUri.setUser(user);
             cogUri.setPassword(password);
-        }
-        if (awsRegion != null) {
-            URI uri = cogUri.getUri();
-            URI newUri = new URI(uri.getScheme(), uri.getUserInfo(), uri.getHost(), uri.getPort(), uri.getPath(), "region=" + awsRegion, uri.getFragment());
-            cogUri.setUri(newUri);
         }
         RangeReader rangeReader = createRangeReader(cogUri);
         CogSourceSPIProvider inputProvider = new CogSourceSPIProvider(cogUri, new CogImageReaderSpi(),
@@ -133,11 +119,7 @@ public class HMStacAsset {
     }
 
     public GridCoverage2D readRaster( RegionMap region ) throws Exception {
-        return readRaster(region, null, null, null);
-    }
-
-    public GridCoverage2D readRaster( RegionMap region, String awsRegion ) throws Exception {
-        return readRaster(region, null, null, awsRegion);
+        return readRaster(region, null, null );
     }
 
     public String getId() {

--- a/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacCollection.java
+++ b/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacCollection.java
@@ -1,5 +1,6 @@
 package org.hortonmachine.gears.io.stac;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -143,12 +144,21 @@ public class HMStacCollection {
         return this;
     }
 
+    private SimpleFeatureCollection queryFeatureCollection() throws IOException {
+        try {
+            return stacClient.search(search, STACClient.SearchMode.POST);
+        } catch (IOException e) {
+            pm.message("POST search query not supported by the endpoint. GET will be tried.");
+        }
+        return stacClient.search(search, STACClient.SearchMode.GET);
+    }
+
     public List<HMStacItem> searchItems() throws Exception {
         if (search == null)
             search = new SearchQuery();
         search.setCollections(Arrays.asList(getId()));
 
-        SimpleFeatureCollection fc = stacClient.search(search, STACClient.SearchMode.GET);
+        SimpleFeatureCollection fc = queryFeatureCollection();
         SimpleFeatureIterator iterator = fc.features();
         pm.beginTask("Extracting STAC items...", -1);
         List<HMStacItem> stacItems = new ArrayList<>();

--- a/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacCollection.java
+++ b/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacCollection.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
+import org.geotools.filter.IllegalFilterException;
 import org.geotools.filter.text.cql2.CQL;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.geometry.jts.JTS;
@@ -108,7 +109,23 @@ public class HMStacCollection {
     public HMStacCollection setGeometryFilter( Geometry intersectionGeometry ) {
         if (search == null)
             search = new SearchQuery();
+        else if (search.getBbox() != null)
+            throw new IllegalStateException("Cannot add intersects filter. Only one of either intersects or bbox may be specified");
         search.setIntersects(intersectionGeometry);
+        return this;
+    }
+
+    /**
+     * Set the geometry bbox filter for search query
+     * @param bbox
+     * @return the current collection.
+     */
+    public HMStacCollection setBboxFilter( double[] bbox ) {
+        if (search == null)
+            search = new SearchQuery();
+        else if (search.getIntersects() != null)
+            throw new IllegalStateException("Cannot add intersects filter. Only one of either intersects or bbox may be specified");
+        search.setBbox(bbox);
         return this;
     }
 

--- a/gears/src/test/java/org/hortonmachine/gears/modules/TestHMStacCollection.java
+++ b/gears/src/test/java/org/hortonmachine/gears/modules/TestHMStacCollection.java
@@ -1,0 +1,78 @@
+package org.hortonmachine.gears.modules;
+
+import org.hortonmachine.gears.io.stac.HMStacCollection;
+import org.hortonmachine.gears.io.stac.HMStacItem;
+import org.hortonmachine.gears.io.stac.HMStacManager;
+import org.hortonmachine.gears.libs.monitor.DummyProgressMonitor;
+import org.hortonmachine.gears.utils.HMTestCase;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Polygon;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+public class TestHMStacCollection extends HMTestCase {
+    private GeometryFactory gf = new GeometryFactory();
+    private DummyProgressMonitor pm = new DummyProgressMonitor();
+    private HMStacManager manager;
+
+    private Coordinate[] createBbox(double xmin, double ymin, double xmax, double ymax) {
+        Coordinate[] bboxCoordinates = new Coordinate[5];
+        bboxCoordinates[0] = new Coordinate(xmin, ymin);
+        bboxCoordinates[1] = new Coordinate(xmin, ymax);
+        bboxCoordinates[2] = new Coordinate(xmax, ymax);
+        bboxCoordinates[3] = new Coordinate(xmax, ymin);
+        bboxCoordinates[4] = new Coordinate(xmin, ymin);
+        return bboxCoordinates;
+    }
+
+    protected void setUp() throws Exception {
+        super.setUp();
+
+        String catalogUrl = "https://planetarycomputer.microsoft.com/api/stac/v1";
+        manager = new HMStacManager(catalogUrl, pm);
+        manager.open();
+    }
+
+    public void testSearchCatalogWithValidSpatioTemporalFilters() throws Exception {
+        HMStacCollection collection = manager.getCollectionById("io-lulc-annual-v02");
+        Instant start = Instant.ofEpochMilli(1514764800000L); // 2018-01-01
+        Instant end = start.plus(Duration.ofDays(10));
+        Polygon bboxPolygon = gf.createPolygon(createBbox(0.0, 0.0, 10.0, 10.0));
+
+        List<HMStacItem> items = collection.setTimestampFilter(Date.from(start), Date.from(end))
+                .setGeometryFilter(bboxPolygon)
+                .searchItems();
+
+        assertTrue(!items.isEmpty());
+    }
+
+    public void testSearchCatalogWithInvalidTemporalFilters() throws Exception {
+        HMStacCollection collection = manager.getCollectionById("io-lulc-annual-v02");
+        Instant start = Instant.ofEpochMilli(946688400000L); // 2000-01-01, a year with no data
+        Instant end = start.plus(Duration.ofDays(10));
+        Polygon bboxPolygon = gf.createPolygon(createBbox(0.0, 0.0, 10.0, 10.0));
+
+        List<HMStacItem> items = collection.setTimestampFilter(Date.from(start), Date.from(end))
+                .setGeometryFilter(bboxPolygon)
+                .searchItems();
+
+        assertTrue(items.isEmpty());
+    }
+
+    public void testSearchCatalogWithInvalidSpatialFilters() throws Exception {
+        HMStacCollection collection = manager.getCollectionById("io-lulc-annual-v02");
+        Instant start = Instant.ofEpochMilli(1514764800000L); // 2018-01-01
+        Instant end = start.plus(Duration.ofDays(10));
+        Polygon bboxPolygon = gf.createPolygon(createBbox(190.0, 90.0, 200.0, 100.0)); // out of bounds
+
+        List<HMStacItem> items = collection.setTimestampFilter(Date.from(start), Date.from(end))
+                .setGeometryFilter(bboxPolygon)
+                .searchItems();
+
+        assertTrue(items.isEmpty());
+    }
+}

--- a/gears/src/test/java/org/hortonmachine/gears/modules/TestHMStacCollection.java
+++ b/gears/src/test/java/org/hortonmachine/gears/modules/TestHMStacCollection.java
@@ -14,6 +14,8 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 
+import static org.junit.Assert.assertThrows;
+
 public class TestHMStacCollection extends HMTestCase {
     private GeometryFactory gf = new GeometryFactory();
     private DummyProgressMonitor pm = new DummyProgressMonitor();
@@ -74,5 +76,32 @@ public class TestHMStacCollection extends HMTestCase {
                 .searchItems();
 
         assertTrue(items.isEmpty());
+    }
+
+    public void testSearchCatalogUsingBbox() throws Exception {
+        HMStacCollection collection = manager.getCollectionById("io-lulc-annual-v02");
+        Instant start = Instant.ofEpochMilli(1514764800000L); // 2018-01-01
+        Instant end = start.plus(Duration.ofDays(10));
+        double[] bbox = {0.0, 0.0, 10.0, 10.0};
+
+        List<HMStacItem> items = collection.setTimestampFilter(Date.from(start), Date.from(end))
+                .setBboxFilter(bbox)
+                .searchItems();
+
+        assertTrue(!items.isEmpty());
+    }
+
+    public void testSearchThrowsExceptionUsingBothBboxAndIntersect() throws Exception {
+        HMStacCollection collection = manager.getCollectionById("io-lulc-annual-v02");
+        Instant start = Instant.ofEpochMilli(1514764800000L); // 2018-01-01
+        Instant end = start.plus(Duration.ofDays(10));
+        Polygon bboxPolygon = gf.createPolygon(createBbox(0.0, 0.0, 10.0, 10.0));
+        double[] bbox = {0.0, 0.0, 10.0, 10.0};
+
+        assertThrows(IllegalStateException.class, () -> collection.setTimestampFilter(Date.from(start), Date.from(end))
+                .setGeometryFilter(bboxPolygon)
+                .setBboxFilter(bbox)
+                .searchItems()
+        );
     }
 }

--- a/gears/src/test/java/org/hortonmachine/gears/modules/TestStacAsset.java
+++ b/gears/src/test/java/org/hortonmachine/gears/modules/TestStacAsset.java
@@ -3,10 +3,14 @@ package org.hortonmachine.gears.modules;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.geotools.coverage.grid.GridCoverage2D;
 import org.hortonmachine.gears.io.stac.HMStacAsset;
+import org.hortonmachine.gears.io.stac.HMStacUtils;
 import org.hortonmachine.gears.utils.HMTestCase;
+import org.hortonmachine.gears.utils.RegionMap;
 
 public class TestStacAsset extends HMTestCase {
+    private ObjectMapper mapper = new ObjectMapper();
 
     protected void setUp() throws Exception {
 
@@ -17,7 +21,6 @@ public class TestStacAsset extends HMTestCase {
 
     public void testCreateValidStacAsset() throws JsonProcessingException {
         String assetJSON = "{\"title\":\"Band 1 (coastal) BOA reflectance\",\"type\":\"image/tiff; application=geotiff; profile=cloud-optimized\",\"roles\":[\"data\"],\"gsd\":60,\"eo:bands\":[{\"name\":\"B01\",\"common_name\":\"coastal\",\"center_wavelength\":0.4439,\"full_width_half_max\":0.027}],\"href\":\"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B01.tif\",\"proj:shape\":[1830,1830],\"proj:transform\":[60,0,399960,0,-60,4200000,0,0,1],\"raster:bands\":[{\"data_type\":\"uint16\",\"spatial_resolution\":60,\"bits_per_sample\":15,\"nodata\":0,\"statistics\":{\"minimum\":1,\"maximum\":20567,\"mean\":2339.4759595597,\"stddev\":3026.6973619954,\"valid_percent\":99.83}}]}";
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode node = mapper.readTree(assetJSON);
 
         HMStacAsset asset = new HMStacAsset("B01", node);
@@ -32,7 +35,6 @@ public class TestStacAsset extends HMTestCase {
 
     public void testCreateInvalidStacAssetTypeInformationNotAvailable() throws JsonProcessingException {
         String assetJSON = "{\"title\":\"Band 1 (coastal) BOA reflectance\",\"roles\":[\"data\"],\"gsd\":60,\"eo:bands\":[{\"name\":\"B01\",\"common_name\":\"coastal\",\"center_wavelength\":0.4439,\"full_width_half_max\":0.027}],\"href\":\"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B01.tif\",\"proj:shape\":[1830,1830],\"proj:transform\":[60,0,399960,0,-60,4200000,0,0,1],\"raster:bands\":[{\"data_type\":\"uint16\",\"spatial_resolution\":60,\"bits_per_sample\":15,\"nodata\":0,\"statistics\":{\"minimum\":1,\"maximum\":20567,\"mean\":2339.4759595597,\"stddev\":3026.6973619954,\"valid_percent\":99.83}}]}";
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode node = mapper.readTree(assetJSON);
 
         HMStacAsset asset = new HMStacAsset("B01", node);
@@ -43,7 +45,6 @@ public class TestStacAsset extends HMTestCase {
 
     public void testCreateInvalidStacAssetNotACOG() throws JsonProcessingException {
         String assetJSON = "{\"title\":\"Band 1 (coastal) BOA reflectance\",\"type\":\"image/tiff;\",\"roles\":[\"data\"],\"gsd\":60,\"eo:bands\":[{\"name\":\"B01\",\"common_name\":\"coastal\",\"center_wavelength\":0.4439,\"full_width_half_max\":0.027}],\"href\":\"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B01.tif\",\"proj:shape\":[1830,1830],\"proj:transform\":[60,0,399960,0,-60,4200000,0,0,1],\"raster:bands\":[{\"data_type\":\"uint16\",\"spatial_resolution\":60,\"bits_per_sample\":15,\"nodata\":0,\"statistics\":{\"minimum\":1,\"maximum\":20567,\"mean\":2339.4759595597,\"stddev\":3026.6973619954,\"valid_percent\":99.83}}]}";
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode node = mapper.readTree(assetJSON);
 
         HMStacAsset asset = new HMStacAsset("B01", node);
@@ -54,7 +55,6 @@ public class TestStacAsset extends HMTestCase {
 
     public void testCreateStacAssetRasterBandsMetadataMissingIsValid() throws JsonProcessingException {
         String assetJSON = "{\"title\":\"Band 1 (coastal) BOA reflectance\",\"type\":\"image/tiff; application=geotiff; profile=cloud-optimized\",\"roles\":[\"data\"],\"gsd\":60,\"eo:bands\":[{\"name\":\"B01\",\"common_name\":\"coastal\",\"center_wavelength\":0.4439,\"full_width_half_max\":0.027}],\"href\":\"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B01.tif\",\"proj:shape\":[1830,1830],\"proj:transform\":[60,0,399960,0,-60,4200000,0,0,1],\"raster:bands\":[]}";
-        ObjectMapper mapper = new ObjectMapper();
         JsonNode node = mapper.readTree(assetJSON);
 
         HMStacAsset asset = new HMStacAsset("B01", node);
@@ -62,4 +62,28 @@ public class TestStacAsset extends HMTestCase {
         assertTrue(asset.isValid());
     }
 
+    public void testReadRasterFromHTTP() throws Exception {
+        String assetJSON = "{\"title\":\"Band 1 (coastal) BOA reflectance\",\"type\":\"image/tiff; application=geotiff; profile=cloud-optimized\",\"roles\":[\"data\"],\"gsd\":60,\"eo:bands\":[{\"name\":\"B01\",\"common_name\":\"coastal\",\"center_wavelength\":0.4439,\"full_width_half_max\":0.027}],\"href\":\"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B01.tif\",\"proj:shape\":[1830,1830],\"proj:transform\":[60,0,399960,0,-60,4200000,0,0,1],\"raster:bands\":[{\"data_type\":\"uint16\",\"spatial_resolution\":60,\"bits_per_sample\":15,\"nodata\":0,\"statistics\":{\"minimum\":1,\"maximum\":20567,\"mean\":2339.4759595597,\"stddev\":3026.6973619954,\"valid_percent\":99.83}}]}";
+        JsonNode node = mapper.readTree(assetJSON);
+        String assetId = "rainfall";
+        HMStacAsset hmAsset = new HMStacAsset(assetId, node);
+        RegionMap regionMap = RegionMap.fromBoundsAndGrid(1640000.0, 1640200.0, 5140000.0, 5140160.0, 20, 16);
+
+        GridCoverage2D grid = hmAsset.readRaster(regionMap);
+
+        assertNotNull(grid);
+    }
+
+    // need setup for AWS credentials in System
+    public void disabledTestReadRasterFromS3() throws Exception {
+        String assetJSON = "{\"href\":\"s3://sentinel-cogs/sentinel-s2-l2a-cogs/5/C/MK/2018/10/S2B_5CMK_20181020_0_L2A/B01.tif\",\"type\":\"image/tiff; application=geotiff; profile=cloud-optimized\",\"title\":\"rainfall\",\"eo:bands\":[{\"name\":\"rainfall\"}],\"proj:epsg\":4326,\"proj:shape\":[1600,1500],\"proj:transform\":[0.05000000074505806,0,-20,0,-0.05000000074505806,40,0,0,1],\"roles\":[\"data\"]}},\"bbox\":[-20,-40.000001192092896,55.00000111758709,40],\"stac_extensions\":[\"https://stac-extensions.github.io/eo/v1.1.0/schema.json\",\"https://stac-extensions.github.io/projection/v1.1.0/schema.json\"],\"collection\":\"rainfall_chirps_monthly\"}";
+        JsonNode node = mapper.readTree(assetJSON);
+        String assetId = "rainfall";
+        HMStacAsset hmAsset = new HMStacAsset(assetId, node);
+        RegionMap regionMap = RegionMap.fromBoundsAndGrid(1640000.0, 1640200.0, 5140000.0, 5140160.0, 20, 16);
+
+        GridCoverage2D grid = hmAsset.readRaster(regionMap);
+
+        assertNotNull(grid);
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -397,6 +397,11 @@
 				<artifactId>imageio-ext-cog-rangereader-http</artifactId>
 				<version>${imageio.ext.version}</version>
 			</dependency>
+			<dependency>
+				<groupId>it.geosolutions.imageio-ext</groupId>
+				<artifactId>imageio-ext-cog-rangereader-s3</artifactId>
+				<version>${imageio.ext.version}</version>
+			</dependency>
 
 			<dependency>
 				<groupId>joda-time</groupId>


### PR DESCRIPTION
Changelog:
- Support `bbox` as a parameter for search queries.
- Throw exception if using `bbox` and `intersect` parameters at the same time.
- Use `POST` as default method for search operations.
- Support querying rasters over S3.

Some extra notes:
- I have used the `POST` operation as the default method for search queries. I might be better to let the user choose the method they prefer to use.
- The test `TestStacAsset.disabledTestReadRasterFromS3()` requires having AWS credentials as environment variables or system variables. Quoting the error message: `java.lang.RuntimeException: No region info found for alias S3.  Please set environment variable 'IIO_S3_AWS_REGION' or system property 'iio.s3.aws.region'`. Aside from that parameter, we would need to define the AWS access key and secret key. As the library seems to assume that those variables are already defined, I would argue that we should assume the same and let the users manage them from their own systems.