### PR TITLE
Pass s3 credentials as parameters

### DIFF
--- a/gears/pom.xml
+++ b/gears/pom.xml
@@ -145,10 +145,6 @@
 			<groupId>it.geosolutions.imageio-ext</groupId>
 			<artifactId>imageio-ext-cog-rangereader-http</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>it.geosolutions.imageio-ext</groupId>
-			<artifactId>imageio-ext-cog-rangereader-s3</artifactId>
-		</dependency>
 
 		<dependency>
 			<groupId>org.geotools</groupId>
@@ -207,6 +203,10 @@
 			<artifactId>netcdf4</artifactId>
 		</dependency>
 
+		<dependency>
+			<groupId>com.amazonaws</groupId>
+			<artifactId>aws-java-sdk</artifactId>
+		</dependency>
 	</dependencies>
 
 </project>

--- a/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacCollection.java
+++ b/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacCollection.java
@@ -1,16 +1,9 @@
 package org.hortonmachine.gears.io.stac;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.List;
-import java.util.stream.Collectors;
-
+import com.amazonaws.services.s3.AmazonS3;
 import org.geotools.coverage.grid.GridCoverage2D;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureIterator;
-import org.geotools.filter.IllegalFilterException;
 import org.geotools.filter.text.cql2.CQL;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.geometry.jts.JTS;
@@ -39,6 +32,13 @@ import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import org.opengis.referencing.operation.MathTransform;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @SuppressWarnings({"rawtypes"})
 /**
  * A stac collection.
@@ -51,6 +51,7 @@ public class HMStacCollection {
     private Collection collection;
     private SearchQuery search;
     private IHMProgressMonitor pm;
+    private AmazonS3 s3Client;
 
     HMStacCollection( STACClient stacClient, Collection collection, IHMProgressMonitor pm ) {
         this.stacClient = stacClient;
@@ -191,7 +192,7 @@ public class HMStacCollection {
      * @return the final raster.
      * @throws Exception
      */
-    public static HMRaster readRasterBandOnRegion( RegionMap latLongRegionMap, String bandName, List<HMStacItem> items,
+    public HMRaster readRasterBandOnRegion( RegionMap latLongRegionMap, String bandName, List<HMStacItem> items,
             boolean allowTransform, MergeMode mergeMode, IHMProgressMonitor pm ) throws Exception {
 
         if (!allowTransform) {

--- a/gears/src/test/java/org/hortonmachine/gears/modules/TestStacAsset.java
+++ b/gears/src/test/java/org/hortonmachine/gears/modules/TestStacAsset.java
@@ -1,5 +1,9 @@
 package org.hortonmachine.gears.modules;
 
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -7,7 +11,6 @@ import org.geotools.coverage.grid.GridCoverage2D;
 import org.hortonmachine.gears.io.stac.HMStacAsset;
 import org.hortonmachine.gears.utils.HMTestCase;
 import org.hortonmachine.gears.utils.RegionMap;
-import org.junit.After;
 
 import static org.junit.Assert.assertThrows;
 
@@ -76,40 +79,32 @@ public class TestStacAsset extends HMTestCase {
         assertNotNull(grid);
     }
 
+    private AmazonS3 createDefaultS3Client(String region) {
+        AWSCredentials credentials = new BasicAWSCredentials(
+                "accessKey",
+                "secretKey"
+                );
+        AmazonS3 client = AmazonS3ClientBuilder
+                .standard()
+                // We use anonymized credentials for this example.
+                // For testing purposes, add your own credentials and uncomment the following line.
+                //.withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion("us-west-2")
+                .build();
+        client.listBuckets();
+        return client;
+    }
+
     public void testReadRasterFromS3() throws Exception {
-        System.setProperty("aws.accessKeyId", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
-        System.setProperty("aws.secretKey", "AKIAIOSFODNN7EXAMPLE");
-        System.setProperty("iio.s3.aws.region", "us-west-2");
         String assetJSON = "{\"href\":\"s3://sentinel-cogs/sentinel-s2-l2a-cogs/5/C/MK/2018/10/S2B_5CMK_20181020_0_L2A/B01.tif\",\"type\":\"image/tiff; application=geotiff; profile=cloud-optimized\",\"title\":\"rainfall\",\"eo:bands\":[{\"name\":\"rainfall\"}],\"proj:epsg\":4326,\"proj:shape\":[1600,1500],\"proj:transform\":[0.05000000074505806,0,-20,0,-0.05000000074505806,40,0,0,1],\"roles\":[\"data\"]}},\"bbox\":[-20,-40.000001192092896,55.00000111758709,40],\"stac_extensions\":[\"https://stac-extensions.github.io/eo/v1.1.0/schema.json\",\"https://stac-extensions.github.io/projection/v1.1.0/schema.json\"],\"collection\":\"rainfall_chirps_monthly\"}";
         JsonNode node = mapper.readTree(assetJSON);
         String assetId = "rainfall";
         HMStacAsset hmAsset = new HMStacAsset(assetId, node);
         RegionMap regionMap = RegionMap.fromBoundsAndGrid(1640000.0, 1640200.0, 5140000.0, 5140160.0, 20, 16);
+        AmazonS3 s3Client = createDefaultS3Client("us-west-2");
 
-        GridCoverage2D grid = hmAsset.readRaster(regionMap);
+        GridCoverage2D grid = hmAsset.readRaster(regionMap, s3Client);
 
         assertNotNull(grid);
-    }
-
-    public void testReadRasterFromS3FailBucketNotInRegion() throws Exception {
-        System.setProperty("aws.accessKeyId", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY");
-        System.setProperty("aws.secretKey", "AKIAIOSFODNN7EXAMPLE");
-        System.setProperty("iio.s3.aws.region", "us-west-1"); // The bucket is not in this region
-
-        String assetJSON = "{\"href\":\"s3://sentinel-cogs/sentinel-s2-l2a-cogs/5/C/MK/2018/10/S2B_5CMK_20181020_0_L2A/B01.tif\",\"type\":\"image/tiff; application=geotiff; profile=cloud-optimized\",\"title\":\"rainfall\",\"eo:bands\":[{\"name\":\"rainfall\"}],\"proj:epsg\":4326,\"proj:shape\":[1600,1500],\"proj:transform\":[0.05000000074505806,0,-20,0,-0.05000000074505806,40,0,0,1],\"roles\":[\"data\"]}},\"bbox\":[-20,-40.000001192092896,55.00000111758709,40],\"stac_extensions\":[\"https://stac-extensions.github.io/eo/v1.1.0/schema.json\",\"https://stac-extensions.github.io/projection/v1.1.0/schema.json\"],\"collection\":\"rainfall_chirps_monthly\"}";
-        JsonNode node = mapper.readTree(assetJSON);
-        String assetId = "rainfall";
-        HMStacAsset hmAsset = new HMStacAsset(assetId, node);
-        RegionMap regionMap = RegionMap.fromBoundsAndGrid(1640000.0, 1640200.0, 5140000.0, 5140160.0, 20, 16);
-
-        assertThrows(RuntimeException.class, () -> hmAsset.readRaster(regionMap)
-        );
-    }
-
-    @After
-    public void after(){
-        System.clearProperty("aws.accessKeyId");
-        System.clearProperty("aws.secretKey");
-        System.clearProperty("iio.s3.aws.region");
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,7 @@
 
 		<performRelease>false</performRelease>
 
+		<aws.version>1.12.730</aws.version>
 	</properties>
 
 
@@ -397,12 +398,6 @@
 				<artifactId>imageio-ext-cog-rangereader-http</artifactId>
 				<version>${imageio.ext.version}</version>
 			</dependency>
-			<dependency>
-				<groupId>it.geosolutions.imageio-ext</groupId>
-				<artifactId>imageio-ext-cog-rangereader-s3</artifactId>
-				<version>${imageio.ext.version}</version>
-			</dependency>
-
 			<dependency>
 				<groupId>joda-time</groupId>
 				<artifactId>joda-time</artifactId>
@@ -897,6 +892,12 @@
 				<artifactId>junit</artifactId>
 				<version>4.13.1</version>
 				<scope>test</scope>
+			</dependency>
+
+			<dependency>
+				<groupId>com.amazonaws</groupId>
+				<artifactId>aws-java-sdk</artifactId>
+				<version>${aws.version}</version>
 			</dependency>
 
 		</dependencies>


### PR DESCRIPTION
Changelog:
- Use the AWS SDK directly to read S3 endpoints from STAC assets.
- Pass S3 credentials as parameters instead of relying on environment variables or system properties.

