### PR TITLE
Replace AWS dependency

### DIFF
--- a/gears/pom.xml
+++ b/gears/pom.xml
@@ -205,7 +205,7 @@
 
 		<dependency>
 			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
+			<artifactId>aws-java-sdk-core</artifactId>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -896,7 +896,7 @@
 
 			<dependency>
 				<groupId>com.amazonaws</groupId>
-				<artifactId>aws-java-sdk</artifactId>
+				<artifactId>aws-java-sdk-core</artifactId>
 				<version>${aws.version}</version>
 			</dependency>
 


### PR DESCRIPTION
I replaced the base AWS SDK for the core utilities. This reduces the number of dependencies while maintaining those needed for our features.