### PR TITLE
generalize asset type validation

### DIFF
--- a/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacAsset.java
+++ b/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacAsset.java
@@ -47,7 +47,7 @@ public class HMStacAsset {
             if (titleNode != null) {
                 title = titleNode.textValue();
             }
-            if (type.toLowerCase().contains("profile=cloud-optimized")) {
+            if (HMStacUtils.ACCEPTED_TYPES.contains(type.toLowerCase().replace(" ", ""))) {
                 JsonNode rasterBandNode = assetNode.get("raster:bands");
                 if (rasterBandNode != null && !rasterBandNode.isEmpty()) {
                     assetUrl = assetNode.get("href").textValue();
@@ -70,7 +70,7 @@ public class HMStacAsset {
                 }
             } else {
                 isValid = false;
-                nonValidReason = "not a COG";
+                nonValidReason = "not a valid type";
             }
         } else {
             nonValidReason = "type information not available";

--- a/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacAsset.java
+++ b/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacAsset.java
@@ -48,10 +48,10 @@ public class HMStacAsset {
                 title = titleNode.textValue();
             }
             if (HMStacUtils.ACCEPTED_TYPES.contains(type.toLowerCase().replace(" ", ""))) {
+                assetUrl = assetNode.get("href").textValue();
+
                 JsonNode rasterBandNode = assetNode.get("raster:bands");
                 if (rasterBandNode != null && !rasterBandNode.isEmpty()) {
-                    assetUrl = assetNode.get("href").textValue();
-
                     Iterator<JsonNode> rbIterator = rasterBandNode.elements();
                     while( rbIterator.hasNext() ) {
                         JsonNode rbNode = rbIterator.next();
@@ -64,9 +64,6 @@ public class HMStacAsset {
                             resolution = resolNode.asDouble();
                         }
                     }
-                } else {
-                    isValid = false;
-                    nonValidReason = "raster bands metadata missing";
                 }
             } else {
                 isValid = false;

--- a/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacUtils.java
+++ b/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacUtils.java
@@ -2,6 +2,8 @@ package org.hortonmachine.gears.io.stac;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 
@@ -26,4 +28,8 @@ public class HMStacUtils {
         }
         return null;
     }
+
+    final static List<String> ACCEPTED_TYPES = Arrays.asList("image/tiff;application=geotiff", "image/vnd.stac.geotiff",
+            "image/tiff;application=geotiff;profile=cloud-optimized", "image/vnd.stac.geotiff;profile=cloud-optimized", "image/vnd.stac.geotiff;cloud-optimized=true",
+            "application/geo+json");
 }

--- a/gears/src/test/java/org/hortonmachine/gears/modules/TestStacAsset.java
+++ b/gears/src/test/java/org/hortonmachine/gears/modules/TestStacAsset.java
@@ -41,7 +41,7 @@ public class TestStacAsset extends HMTestCase {
         assertEquals("type information not available", asset.getNonValidReason());
     }
 
-    public void testCreateInvalidStacAssetNotACOG() throws JsonProcessingException {
+    public void testCreateInvalidStacAssetNotAValidType() throws JsonProcessingException {
         String assetJSON = "{\"title\":\"Band 1 (coastal) BOA reflectance\",\"type\":\"image/tiff;\",\"roles\":[\"data\"],\"gsd\":60,\"eo:bands\":[{\"name\":\"B01\",\"common_name\":\"coastal\",\"center_wavelength\":0.4439,\"full_width_half_max\":0.027}],\"href\":\"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B01.tif\",\"proj:shape\":[1830,1830],\"proj:transform\":[60,0,399960,0,-60,4200000,0,0,1],\"raster:bands\":[{\"data_type\":\"uint16\",\"spatial_resolution\":60,\"bits_per_sample\":15,\"nodata\":0,\"statistics\":{\"minimum\":1,\"maximum\":20567,\"mean\":2339.4759595597,\"stddev\":3026.6973619954,\"valid_percent\":99.83}}]}";
         ObjectMapper mapper = new ObjectMapper();
         JsonNode node = mapper.readTree(assetJSON);
@@ -49,18 +49,7 @@ public class TestStacAsset extends HMTestCase {
         HMStacAsset asset = new HMStacAsset("B01", node);
 
         assertFalse(asset.isValid());
-        assertEquals("not a COG", asset.getNonValidReason());
-    }
-
-    public void testCreateInvalidStacAssetRasterBandsMetadataMissing() throws JsonProcessingException {
-        String assetJSON = "{\"title\":\"Band 1 (coastal) BOA reflectance\",\"type\":\"image/tiff; application=geotiff; profile=cloud-optimized\",\"roles\":[\"data\"],\"gsd\":60,\"eo:bands\":[{\"name\":\"B01\",\"common_name\":\"coastal\",\"center_wavelength\":0.4439,\"full_width_half_max\":0.027}],\"href\":\"https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/33/S/VB/2021/2/S2B_33SVB_20210221_0_L2A/B01.tif\",\"proj:shape\":[1830,1830],\"proj:transform\":[60,0,399960,0,-60,4200000,0,0,1],\"raster:bands\":[]}";
-        ObjectMapper mapper = new ObjectMapper();
-        JsonNode node = mapper.readTree(assetJSON);
-
-        HMStacAsset asset = new HMStacAsset("B01", node);
-
-        assertFalse(asset.isValid());
-        assertEquals("raster bands metadata missing", asset.getNonValidReason());
+        assertEquals("not a valid type", asset.getNonValidReason());
     }
 
 }


### PR DESCRIPTION
The valid data types were obtained from the following link: https://github.com/radiantearth/stac-spec/blob/master/best-practices.md#common-media-types-in-stac
At this time, the permitted types are as follows:
- GeoTIFF
- Cloud Optimized GeoTIFF
- GeoJSON

The list of types can be modified as necessary.