### PR TITLE
Use Initialized S3 Client to Read Rasters

### DIFF
--- a/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacCollection.java
+++ b/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacCollection.java
@@ -341,7 +341,13 @@ public class HMStacCollection {
 
                     RegionMap readRegion = RegionMap.fromBoundsAndGrid(roiEnvCurrentAssetCrs.getMinX(), roiEnvCurrentAssetCrs.getMaxX(),
                             roiEnvCurrentAssetCrs.getMinY(), roiEnvCurrentAssetCrs.getMaxY(), cols, rows);
-                    GridCoverage2D readRaster = rasterHandler.readRaster(readRegion);
+                    GridCoverage2D readRaster = null;
+
+                    if (this.client != null) {
+                        readRaster = rasterHandler.readRaster(readRegion, client);
+                    } else {
+                        readRaster = rasterHandler.readRaster(readRegion);
+                    }
                     outRaster.mapRaster(null, HMRaster.fromGridCoverage(readRaster), mergeMode);
                     readRaster.dispose(true);
                 }

--- a/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacCollection.java
+++ b/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacCollection.java
@@ -341,13 +341,8 @@ public class HMStacCollection {
 
                     RegionMap readRegion = RegionMap.fromBoundsAndGrid(roiEnvCurrentAssetCrs.getMinX(), roiEnvCurrentAssetCrs.getMaxX(),
                             roiEnvCurrentAssetCrs.getMinY(), roiEnvCurrentAssetCrs.getMaxY(), cols, rows);
-                    GridCoverage2D readRaster = null;
+                    GridCoverage2D readRaster = rasterHandler.readRaster(readRegion, this.client);
 
-                    if (this.client != null) {
-                        readRaster = rasterHandler.readRaster(readRegion, this.client);
-                    } else {
-                        readRaster = rasterHandler.readRaster(readRegion);
-                    }
                     outRaster.mapRaster(null, HMRaster.fromGridCoverage(readRaster), mergeMode);
                     readRaster.dispose(true);
                 }

--- a/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacCollection.java
+++ b/gears/src/main/java/org/hortonmachine/gears/io/stac/HMStacCollection.java
@@ -344,7 +344,7 @@ public class HMStacCollection {
                     GridCoverage2D readRaster = null;
 
                     if (this.client != null) {
-                        readRaster = rasterHandler.readRaster(readRegion, client);
+                        readRaster = rasterHandler.readRaster(readRegion, this.client);
                     } else {
                         readRaster = rasterHandler.readRaster(readRegion);
                     }


### PR DESCRIPTION
Fixes when S3 Client although initialized is not used to read the rasters later when it checks if the asset href starts with "s3://" leading to a NPE. 